### PR TITLE
Make inspiry bot more gender-neutral

### DIFF
--- a/bin/inspiry.rb
+++ b/bin/inspiry.rb
@@ -9,7 +9,7 @@ def get_quote
   author = body["contents"]["quotes"][0]["author"]
   puts "Got a Nice quote from #{author}"
   quote = body["contents"]["quotes"][0]["quote"]
-  puts "He says - #{quote}"
+  puts "This wise person says - #{quote}"
   post_message(author, quote)
 end
 


### PR DESCRIPTION
Currently, inspiry bot assumes that all quote authors are males. I updated the bot with more gender-neutral language. 
